### PR TITLE
Removes the unused braces warning in the autogenerated From implementations.

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -290,9 +290,9 @@ impl BitfieldStruct {
     /// Returns a token stream representing the next greater value divisible by 8.
     fn next_divisible_by_8(value: &TokenStream2) -> TokenStream2 {
         let span = value.span();
-        quote_spanned!(span=> {
+        quote_spanned!(span=>
             (((#value - 1) / 8) + 1) * 8
-        })
+        )
     }
 
     /// Generates the actual item struct definition for the `#[bitfield]`.

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -428,7 +428,7 @@ impl BitfieldStruct {
                     pub fn from_bytes(
                         bytes: [::core::primitive::u8; #next_divisible_by_8 / 8usize]
                     ) -> ::core::result::Result<Self, ::modular_bitfield::error::OutOfBounds> {
-                        if bytes[(#next_divisible_by_8 / 8usize) - 1] >= (0x01 << (8 - (#next_divisible_by_8 - #size))) {
+                        if bytes[(#next_divisible_by_8 / 8usize) - 1] >= (0x01 << (8 - (#next_divisible_by_8 - (#size)))) {
                             return ::core::result::Result::Err(::modular_bitfield::error::OutOfBounds)
                         }
                         ::core::result::Result::Ok(Self { bytes })

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -69,8 +69,7 @@ impl BitfieldStruct {
             impl ::modular_bitfield::Specifier for #ident {
                 const BITS: usize = #bits;
 
-                #[allow(unused_braces)]
-                type Bytes = <[(); if { #bits } > 128 { 128 } else { #bits }] as ::modular_bitfield::private::SpecifierBytes>::Bytes;
+                type Bytes = <[(); if #bits  > 128 { 128 } else { #bits }] as ::modular_bitfield::private::SpecifierBytes>::Bytes;
                 type InOut = Self;
 
                 #[inline]
@@ -169,14 +168,14 @@ impl BitfieldStruct {
     ///
     /// ```
     /// # use modular_bitfield::prelude::*;
-    /// {
-    ///     0usize +
-    ///     <B8 as ::modular_bitfield::Specifier>::BITS +
-    ///     <B8 as ::modular_bitfield::Specifier>::BITS +
-    ///     <B8 as ::modular_bitfield::Specifier>::BITS +
-    ///     <bool as ::modular_bitfield::Specifier>::BITS +
-    ///     <B7 as ::modular_bitfield::Specifier>::BITS
-    /// }
+    ///
+    ///0usize +
+    ///<B8 as ::modular_bitfield::Specifier>::BITS +
+    ///<B8 as ::modular_bitfield::Specifier>::BITS +
+    ///<B8 as ::modular_bitfield::Specifier>::BITS +
+    ///<bool as ::modular_bitfield::Specifier>::BITS +
+    ///<B7 as ::modular_bitfield::Specifier>::BITS
+    ///
     /// # ;
     /// ```
     ///
@@ -200,7 +199,7 @@ impl BitfieldStruct {
                 )
             });
         quote_spanned!(span=>
-            { #sum }
+            #sum
         )
     }
 
@@ -265,7 +264,7 @@ impl BitfieldStruct {
             #[allow(clippy::identity_op)]
             const _: () = {
                 impl ::modular_bitfield::private::checks::#check_ident for #ident {
-                    type Size = ::modular_bitfield::private::checks::TotalSize<[(); #actual_bits % 8usize]>;
+                    type Size = ::modular_bitfield::private::checks::TotalSize<[(); (#actual_bits) % 8usize]>;
                 }
             };
         )

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -195,7 +195,7 @@ impl BitfieldStruct {
             })
             .fold(quote_spanned!(span=> 0usize), |lhs, rhs| {
                 quote_spanned!(span =>
-                    (#lhs + #rhs)
+                    #lhs + #rhs
                 )
             });
         quote_spanned!(span=>

--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -169,12 +169,12 @@ impl BitfieldStruct {
     /// ```
     /// # use modular_bitfield::prelude::*;
     ///
-    ///0usize +
-    ///<B8 as ::modular_bitfield::Specifier>::BITS +
-    ///<B8 as ::modular_bitfield::Specifier>::BITS +
-    ///<B8 as ::modular_bitfield::Specifier>::BITS +
-    ///<bool as ::modular_bitfield::Specifier>::BITS +
-    ///<B7 as ::modular_bitfield::Specifier>::BITS
+    /// 0usize +
+    /// <B8 as ::modular_bitfield::Specifier>::BITS +
+    /// <B8 as ::modular_bitfield::Specifier>::BITS +
+    /// <B8 as ::modular_bitfield::Specifier>::BITS +
+    /// <bool as ::modular_bitfield::Specifier>::BITS +
+    /// <B7 as ::modular_bitfield::Specifier>::BITS
     ///
     /// # ;
     /// ```
@@ -195,7 +195,7 @@ impl BitfieldStruct {
             })
             .fold(quote_spanned!(span=> 0usize), |lhs, rhs| {
                 quote_spanned!(span =>
-                    #lhs + #rhs
+                    (#lhs + #rhs)
                 )
             });
         quote_spanned!(span=>


### PR DESCRIPTION
Resolves #66.

Previously, `From` implementations may have expanded to code similar to the
following:

```
...
where
    [(); { Size }]:
        ::modular_bitfield::private::IsU32Compatible,
...
```

Where `Size` is a constant expression that reduces to a `usize`.
With `Size` being an expression and the context in which it is used, the braces
around it are unneeded, producing a warning.

The braces are inserted in `impl::bitfield::expand::generate_bitfield_size`,
surrounding the returned sum-expression.

To avoid the warning, `generate_bitfield_size` was modified to return a naked
expression.

Places where brackets were needed to avoid an incorrect reading of the
expression were modified to add the brackets in place.
Similarly, places where the brackets were not needed were simplified.

----------------------------------------------------------------------------------------------

- Tests, even on a clean download of the repository, seems to be currently broken, at least on my system, with multiple failing testes and a certain amount of panics.
  
  This means that I was unable to use the tests to avoid regressions or prescribed errors. I cannot, hence, be sure about the   correctness of each case.

If this is intended to be accepted, please let me know what I should do meet quality control, be it adding tests or something else.