### PR TITLE
Add optional support for ufmt crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,18 @@ version.workspace = true
 [dependencies]
 modular-bitfield-impl = { path = "impl", version = "0.13.0-pre" }
 static_assertions = "1.1"
+ufmt = { version = "0.2.0", default-features = false, optional = true }
 
 [dev-dependencies]
 bitfield = "0.19"
 tiny-bench = "0.4"
 trybuild = "1.0"
+ufmt = { version = "0.2.0", default-features = false }
+
+[features]
+# Add support for `#[derive(uDebug)]` from [ufmt](https://docs.rs/ufmt/latest)
+ufmt = ["modular-bitfield-impl/ufmt", "dep:ufmt"]
+default = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Implements the `#[bitfield]` macros introduced and specified in David Tolnay's [
 
 Thanks go to David Tolnay for designing the specification for the macros implemented in this crate.
 
+## Optional Cargo Features
+- **`ufmt`**: Support for the [ufmt](https://docs.rs/ufmt/latest) crate.
+  - This creates better output when using `#[derive(uDebug)]` on bitfield structs analogous to `#[derive(Debug)]` which generally results in lower binary size/higher performance compared to the standard `Debug` code on most platforms.
+    
+    See the [`#[bitfield]` documentation](docs/bitfield.md#support-deriveudebug)
+
 ## Usage
 
 Annotate a Rust struct with the `#[bitfield]` attribute in order to convert it into a bitfield.

--- a/docs/bitfield.md
+++ b/docs/bitfield.md
@@ -227,6 +227,16 @@ is going to be generated that clearly displays all the fields and their values a
 would expect.
 Also invalid bit patterns for fields are clearly displayed under this implementation.
 
+## Support: `#[derive(uDebug)]`
+Requires the `ufmt` feature.
+
+If a `#[derive(uDebug)]` is found by the `#[bitfield]` a naturally formatting implementation
+is going to be generated that clearly displays all the fields and their values as the user
+would expect.
+Also invalid bit patterns for fields are clearly displayed under this implementation.
+
+This behaves the same as `#[derive(Debug)]` regarding the output, but implements `ufmt::uDebug` of the [ufmt](https://docs.rs/ufmt/latest) crate.
+
 ### Example
 
 ```

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,10 +17,16 @@ proc-macro = true
 quote = "1"
 syn = { version = "2", features = ["full"] }
 proc-macro2 = "1"
+ufmt = { version = "0.2.0", optional = true, default-features = false }
 
 [dev-dependencies]
 glob = "0.3"
 runtime-macros = "1.1.1"
+
+[features]
+# Add support for `#[derive(uDebug)]` from [ufmt](https://docs.rs/ufmt/latest)
+ufmt = ["dep:ufmt"]
+default = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/impl/src/bitfield/analyse.rs
+++ b/impl/src/bitfield/analyse.rs
@@ -105,6 +105,9 @@ impl BitfieldStruct {
             let path = &meta.path;
             if path.is_ident("Debug") {
                 config.derive_debug(path.span())?;
+            } else if path.is_ident("uDebug") {
+                #[cfg(feature = "ufmt")]
+                config.derive_udebug(path.span())?;
             } else if path.is_ident("BitfieldSpecifier") {
                 config.deprecated_specifier(path.span());
                 config.derive_specifier(path.span())?;

--- a/impl/src/bitfield/config.rs
+++ b/impl/src/bitfield/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub filled: Option<ConfigValue<bool>>,
     pub repr: Option<ConfigValue<ReprKind>>,
     pub derive_debug: Option<ConfigValue<()>>,
+    #[cfg(feature = "ufmt")]
+    pub derive_udebug: Option<ConfigValue<()>>,
     pub derive_specifier: Option<ConfigValue<()>>,
     pub deprecated_specifier: Option<Span>,
     pub retained_attributes: Vec<syn::Attribute>,
@@ -243,6 +245,26 @@ impl Config {
                 ))
             }
             None => self.derive_debug = Some(ConfigValue::new((), span)),
+        }
+        Ok(())
+    }
+
+    /// Registers the `#[derive(uDebug)]` attribute for the #[bitfield] macro.
+    ///
+    /// # Errors
+    ///
+    /// If a `#[derive(uDebug)]` attribute has already been found.
+    #[cfg(feature = "ufmt")]
+    pub fn derive_udebug(&mut self, span: Span) -> Result<()> {
+        match &self.derive_udebug {
+            Some(previous) => {
+                return Err(Self::raise_duplicate_error(
+                    "#[derive(uDebug)]",
+                    span,
+                    previous,
+                ))
+            }
+            None => self.derive_udebug = Some(ConfigValue::new((), span)),
         }
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 //! Errors that can occur while operating on modular bitfields.
 
 use core::fmt::Debug;
+#[cfg(feature = "ufmt")]
+use ufmt::derive::uDebug;
 
 /// The given value was out of range for the bitfield.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -14,6 +16,7 @@ impl core::fmt::Display for OutOfBounds {
 
 /// The bitfield contained an invalid bit pattern.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "ufmt", derive(uDebug))]
 pub struct InvalidBitPattern<Bytes> {
     /// The invalid bits.
     invalid_bytes: Bytes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod error;
 #[doc(hidden)]
 pub mod private;
 
+#[cfg(feature = "ufmt")]
+use ufmt::{uDebug, uWrite};
 use self::error::{InvalidBitPattern, OutOfBounds};
 
 #[doc = include_str!("../docs/bitfield.md")]
@@ -17,6 +19,29 @@ pub use modular_bitfield_impl::Specifier;
 
 #[doc(hidden)]
 pub use modular_bitfield_impl::BitfieldSpecifier;
+
+/// Enum for either the value of a bitfield, or the error resulting from trying to read it.
+#[cfg(feature = "ufmt")]
+pub enum FieldValueOrError<F, E> {
+    /// Read field value
+    FieldValue(F),
+    /// Error returned when trying to read a field
+    Error(E),
+}
+
+#[cfg(feature = "ufmt")]
+impl<F: uDebug, E: uDebug> uDebug for FieldValueOrError<F, E> {
+    #[inline]
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized
+    {
+        match self {
+            FieldValueOrError::FieldValue(value) => value.fmt(f),
+            FieldValueOrError::Error(value) => value.fmt(f),
+        }
+    }
+}
 
 /// The prelude: `use modular_bitfield::prelude::*;`
 pub mod prelude {

--- a/tests/bitfield/derive_udebug.rs
+++ b/tests/bitfield/derive_udebug.rs
@@ -1,0 +1,189 @@
+#![cfg(feature = "ufmt")]
+
+//! Tests for `#[derive(Debug)]`
+
+extern crate alloc;
+use core::fmt::Write;
+use ufmt::derive::uDebug;
+use ufmt::{uWrite, uwrite};
+use modular_bitfield::prelude::*;
+
+#[derive(Debug)]
+pub struct AllocString(alloc::string::String);
+
+impl uWrite for AllocString {
+    type Error = ();
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.0.write_str(s).map_err(|_|())
+    }
+}
+
+impl AllocString {
+    pub fn new() -> Self {
+        Self(alloc::string::String::new())
+    }
+}
+
+impl<'s> PartialEq<&'s str> for AllocString {
+    fn eq(&self, other: &&'s str) -> bool {
+        self.0 == *other
+    }
+}
+
+macro_rules! ufmt_format_wrapper {
+    ($($tt:tt)*) => {{
+        let mut s = AllocString::new();
+        uwrite!(s, $($tt)*).unwrap();
+        s
+    }};
+}
+
+#[test]
+fn print_invalid_bits() {
+    #[derive(Specifier, uDebug)]
+    #[bits = 2]
+    pub enum Status {
+        Green = 0,
+        Yellow = 1,
+        Red = 2, // 0x11 (= 3) is undefined here for Status!
+    }
+
+    #[bitfield]
+    #[derive(uDebug)]
+    pub struct DataPackage {
+        status: Status,
+        contents: B4,
+        is_alive: bool,
+        is_received: bool,
+    }
+
+    let package = DataPackage::from_bytes([0b0101_1011]);
+    assert_eq!(
+        ufmt_format_wrapper!("{:?}", package),
+        "DataPackage { status: InvalidBitPattern { invalid_bytes: 3 }, contents: 6, is_alive: true, is_received: false }",
+    );
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", package),
+        "DataPackage {\n    \
+            status: InvalidBitPattern {\n        \
+                invalid_bytes: 3,\n    \
+            },\n    \
+            contents: 6,\n    \
+            is_alive: true,\n    \
+            is_received: false,\n\
+        }",
+    );
+}
+
+#[test]
+fn respects_other_derives() {
+    #[bitfield]
+    #[derive(Debug, uDebug, Clone, PartialEq, Eq)]
+    pub struct Color {
+        r: B6,
+        g: B6,
+        b: B6,
+        a: B6,
+    }
+
+    let color1 = Color::new().with_r(63).with_g(32).with_b(16).with_a(8);
+    let color2 = color1.clone();
+    assert_eq!(color1, color2);
+    assert_eq!(ufmt_format_wrapper!("{:?}", color1), "Color { r: 63, g: 32, b: 16, a: 8 }",);
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", color2),
+        "Color {\n    r: 63,\n    g: 32,\n    b: 16,\n    a: 8,\n}",
+    );
+}
+
+#[test]
+fn valid_use_2() {
+    #[derive(Specifier, uDebug)]
+    pub enum Status {
+        Green,
+        Yellow,
+        Red,
+        None,
+    }
+
+    #[bitfield]
+    #[derive(uDebug)]
+    pub struct DataPackage {
+        status: Status,
+        contents: B60,
+        is_alive: bool,
+        is_received: bool,
+    }
+
+    let package = DataPackage::new()
+        .with_status(Status::Green)
+        .with_contents(0xC0DE_CAFE)
+        .with_is_alive(true)
+        .with_is_received(false);
+    assert_eq!(
+        ufmt_format_wrapper!("{:?}", package),
+        "DataPackage { status: Green, contents: 3235826430, is_alive: true, is_received: false }",
+    );
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", package),
+        "DataPackage {\n    status: Green,\n    contents: 3235826430,\n    is_alive: true,\n    is_received: false,\n}",
+    );
+}
+
+#[test]
+fn valid_use_specifier() {
+    #[bitfield(filled = false)] // Requires just 4 bits!
+    #[derive(Specifier, uDebug)]
+    pub struct Header {
+        status: B2,
+        is_alive: bool,
+        is_received: bool,
+    }
+
+    let header = Header::new()
+        .with_status(1)
+        .with_is_alive(true)
+        .with_is_received(false);
+    assert_eq!(
+        ufmt_format_wrapper!("{:?}", header),
+        "Header { status: 1, is_alive: true, is_received: false }",
+    );
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", header),
+        "Header {\n    status: 1,\n    is_alive: true,\n    is_received: false,\n}",
+    );
+}
+
+#[test]
+fn valid_use() {
+    #[bitfield]
+    #[derive(uDebug)]
+    pub struct Color {
+        r: B6,
+        g: B6,
+        b: B6,
+        a: B6,
+    }
+
+    let color = Color::new().with_r(63).with_g(32).with_b(16).with_a(8);
+    assert_eq!(ufmt_format_wrapper!("{:?}", color), "Color { r: 63, g: 32, b: 16, a: 8 }",);
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", color),
+        "Color {\n    r: 63,\n    g: 32,\n    b: 16,\n    a: 8,\n}",
+    );
+}
+
+#[test]
+fn valid_use_tuple() {
+    #[bitfield]
+    #[derive(uDebug)]
+    pub struct Color(B6, B6, B6, B6);
+
+    let color = Color::new().with_0(63).with_1(32).with_2(16).with_3(8);
+    assert_eq!(ufmt_format_wrapper!("{:?}", color), "Color(63, 32, 16, 8)",);
+    assert_eq!(
+        ufmt_format_wrapper!("{:#?}", color),
+        "Color(\n    63,\n    32,\n    16,\n    8,\n)",
+    );
+}

--- a/tests/bitfield/derive_udebug.rs
+++ b/tests/bitfield/derive_udebug.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "ufmt")]
 
-//! Tests for `#[derive(Debug)]`
+//! Tests for `#[derive(uDebug)]`
 
 extern crate alloc;
 use core::fmt::Write;
@@ -31,6 +31,7 @@ impl<'s> PartialEq<&'s str> for AllocString {
     }
 }
 
+/// Wrapper for ufmt's uwrite!() macro to return an AllocString, analogous to the format!() macro.
 macro_rules! ufmt_format_wrapper {
     ($($tt:tt)*) => {{
         let mut s = AllocString::new();

--- a/tests/bitfield/mod.rs
+++ b/tests/bitfield/mod.rs
@@ -2,6 +2,8 @@ mod bits_param;
 mod bytes_param;
 mod derive_bitfield_specifier;
 mod derive_debug;
+#[cfg(feature = "ufmt")]
+mod derive_udebug;
 mod derive_specifier;
 mod filled_param;
 mod no_implicit_prelude;

--- a/tests/ui/derive_udebug/duplicate_derive_udebug.rs
+++ b/tests/ui/derive_udebug/duplicate_derive_udebug.rs
@@ -1,0 +1,10 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[derive(uDebug)] #[derive(uDebug)]
+pub struct SignedInt {
+    sign: bool,
+    value: B31,
+}
+
+fn main() {}

--- a/tests/ui/derive_udebug/duplicate_derive_udebug.stderr
+++ b/tests/ui/derive_udebug/duplicate_derive_udebug.stderr
@@ -1,0 +1,11 @@
+error: encountered duplicate `#[derive(uDebug)]` parameter
+ --> tests/ui/derive_udebug/duplicate_derive_udebug.rs:4:28
+  |
+4 | #[derive(uDebug)] #[derive(uDebug)]
+  |                            ^^^^^^
+
+error: previous `#[derive(uDebug)]` parameter here
+ --> tests/ui/derive_udebug/duplicate_derive_udebug.rs:4:10
+  |
+4 | #[derive(uDebug)] #[derive(uDebug)]
+  |          ^^^^^^

--- a/tests/ui/derive_udebug/duplicate_derive_udebug_2.rs
+++ b/tests/ui/derive_udebug/duplicate_derive_udebug_2.rs
@@ -1,0 +1,10 @@
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[derive(uDebug, uDebug)]
+pub struct SignedInt {
+    sign: bool,
+    value: B31,
+}
+
+fn main() {}

--- a/tests/ui/derive_udebug/duplicate_derive_udebug_2.stderr
+++ b/tests/ui/derive_udebug/duplicate_derive_udebug_2.stderr
@@ -1,0 +1,11 @@
+error: encountered duplicate `#[derive(uDebug)]` parameter
+ --> tests/ui/derive_udebug/duplicate_derive_udebug_2.rs:4:18
+  |
+4 | #[derive(uDebug, uDebug)]
+  |                  ^^^^^^
+
+error: previous `#[derive(uDebug)]` parameter here
+ --> tests/ui/derive_udebug/duplicate_derive_udebug_2.rs:4:10
+  |
+4 | #[derive(uDebug, uDebug)]
+  |          ^^^^^^


### PR DESCRIPTION
This adds support for `#[derive(uDebug)]` which is an analog of the [ufmt](https://docs.rs/ufmt/latest) crate to the `#[derive(Debug)]`, but with generally a lot smaller code size and apparently better performance:

> `μfmt`, a (6-40x) smaller, (2-9x) faster and panic-free alternative to `core::fmt`
> 
> -- <cite>ufmt's documentation</cite>

# Why I think, this is a good addition
1. Code size is sometimes pretty important, for example on embedded systems, which also make use of optimized bitfields (so this crate) and _ufmt_ provides exactly that.
2. Implementing this in a separate crate would make life pretty hard for users, as it would generate a relatively hard dependency on the versions of both, this crate and _ufmt_.
3. Most of my projects for Arduino boards fail to compile with `#[derive(Debug)]` due to too large binary size but compile fine with `#[derive(uDebug)]`.

# Open questions
1. _ufmt_ had it's last update 3 years ago, but seems to be stable in its current release. Is this a problem?
2. Would it be better to add an additional test, which just runs the _ufmt_-specific tests with hard-enabled `ufmt`-feature, so that the correct functionality is tested, even if one does not explicitly enable the feature in testing?

# Implementation details
1. I added an disabled-by-default feature `ufmt` which adds the support and an additional dependency to `ufmt`, making updates to either crate hard to amlost-impossible
2. I duplicated the code generation of `#[derive(Debug)]` and modified them appropriately
3. I needed to add an extra enum `FieldValueOrError` because _ufmt_'s `fmt()` implementation uses references to types instead of `&dyn Debug` or similar and this seems to be the best performance/code size approach to be able to display both, the field value and its getter's error
4. I copied and modified all tests (including ui) for `#[derive(Debug)]` and modified them accordingly
5. Documentation has been extended